### PR TITLE
Some changes EggRatingViewController.swift

### DIFF
--- a/EggRating/Classes/EggRatingViewController.swift
+++ b/EggRating/Classes/EggRatingViewController.swift
@@ -89,8 +89,8 @@ class EggRatingViewController: UIViewController {
     
     func sendUserToAppStore() {
         
-        guard let url = NSURL(string: "itms-apps://itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?id=\(EggRating.itunesId)&onlyLatestVersion=true&pageNumber=0&sortOrdering=1&type=Purple+Software") as? URL else {
-           return
+        guard let url = URL(string: "itms-apps://itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?id=\(EggRating.itunesId)&onlyLatestVersion=true&pageNumber=0&sortOrdering=1&type=Purple+Software") else {
+            return
         }
         
         UIApplication.shared.openURL(url)


### PR DESCRIPTION
Conditional downcast from ’NSURL?’ to ‘URL’ is a bridging conversion warning fixed.