### PR TITLE
Add support for customization in the case of a poor rating.

### DIFF
--- a/EggRating/Classes/EggRatingViewController.swift
+++ b/EggRating/Classes/EggRatingViewController.swift
@@ -16,6 +16,15 @@ public protocol EggRatingDelegate {
     func didIgnoreToRate()
     func didRateOnAppStore()
     func didIgnoreToRateOnAppStore()
+    
+    /// If this method returns false, the disadvantage alert will not be shown when the user rates the app poorly. This provides an opportunity for clients to provide custom behavior in such a case.
+    func shouldPresentDisadvantageAlert() -> Bool
+}
+
+extension EggRatingDelegate {
+    func shouldPresentDisadvantageAlert() -> Bool {
+        return true
+    }
 }
 
 class EggRatingViewController: UIViewController {
@@ -119,7 +128,7 @@ class EggRatingViewController: UIViewController {
             // only save last rated version if user rates more than mininum score
             UserDefaults.standard.set(EggRating.appVersion, forKey: EggRatingUserDefaultsKey.lastVersionRatedKey.rawValue)
             
-        } else {
+        } else if let delegate = delegate, delegate.shouldPresentDisadvantageAlert() {
             showDisadvantageAlertController()
         }
         

--- a/Example/EggRating/EggRatingTableViewController.swift
+++ b/Example/EggRating/EggRatingTableViewController.swift
@@ -123,6 +123,9 @@ class EggRatingTableViewController: UITableViewController {
 }
 
 extension EggRatingTableViewController: EggRatingDelegate {
+    func shouldPresentDisadvantageAlert() -> Bool {
+        return true
+    }
     
     func didRate(rating: Double) {
         print("didRate: \(rating)")


### PR DESCRIPTION
In an app I am working on, we don't want the "Thank You" alert to be shown in the case of a poor rating. This change allows clients to customize this behavior.